### PR TITLE
Fixed display of outline showing html tags.

### DIFF
--- a/src/main/resources/templates/showListOfTutorial.html
+++ b/src/main/resources/templates/showListOfTutorial.html
@@ -157,7 +157,8 @@
 				
 						<div class="row">
 									
-				<h6>Outline :</h6> &nbsp; <h6 style="color: blue;" th:text="${tutorial.getOutlin()}"></h6>
+				<h6>Outline :</h6> &nbsp; 
+				<h6 style="color: blue;" th:utext="${tutorial.getOutlin()}"></h6>
 								    
 						</div>
 				


### PR DESCRIPTION
Fixed display of tutorial outline getting displayed with html tags in tutorial list page.